### PR TITLE
Fix gpiolib.c warning during compilation

### DIFF
--- a/drivers/gpio/gpiolib.c
+++ b/drivers/gpio/gpiolib.c
@@ -21,7 +21,7 @@
 #define CREATE_TRACE_POINTS
 #include <trace/events/gpio.h>
 /*add for dash adapter update*/
-#include "../power/oem_external_fg.h"e
+#include "../power/oem_external_fg.h"
 
 /* Implementation infrastructure for GPIO interfaces.
  *


### PR DESCRIPTION
Fix warning during compilation :

drivers/gpio/gpiolib.c:24:38: warning: extra tokens at end of #include directive
 #include "../power/oem_external_fg.h"e
